### PR TITLE
Fixed bug with G_estimate_randint dimensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Ruserdata
 *NOTES.R
 *.Rproj
+rebuild.Rmd

--- a/R/G_estimate_randint.R
+++ b/R/G_estimate_randint.R
@@ -4,6 +4,7 @@
 #' of the FUI method. A helper function for `fui`.
 #'
 #' @param data A data frame containing all variables in formula
+#' @param L Number of columns of outcome variables
 #' @param out_index Indices that contain the outcome variables
 #' @param designmat Design matrix of the linear models
 #' @param betaHat Estimated functional fixed effects
@@ -14,13 +15,12 @@
 #'
 #' @importFrom Matrix crossprod
 
-# TODO: check function dependencies
-
 # Derive covariance estimates of random components: G(s1,s2)
 ### Create a function that estimates covariance G for random intercepts
 
 G_estimate_randint <- function(
   data,
+  L,
   out_index,
   designmat,
   betaHat,
@@ -30,19 +30,22 @@ G_estimate_randint <- function(
   if(silent == FALSE)
     print("Step 3.1.1: Method of Moments Covariance Estimator Random Intercept")
 
-  L <- length(out_index)
   GTilde <- matrix(NA, nrow = L, ncol = L)
   vdm <- crossprod(betaHat, var(designmat) %*% betaHat)
-  d_temp <- data[,out_index]
+  d_temp <- data[, out_index]
 
   for(i in 1:L) {
     bhatVdm <- vdm[,i]
     d_temp_i <- d_temp[,i]
     res_temp <- GTilde[i,]
     for(j in 1:L){
-      res_temp[j] <- stats::cov(d_temp_i, d_temp[,j], use = "pairwise.complete.obs") - bhatVdm[j]
+      res_temp[j] <- stats::cov(
+        d_temp_i,
+        d_temp[,j],
+        use = "pairwise.complete.obs"
+      ) - bhatVdm[j]
     }
-    GTilde[i,] <- res_temp
+    GTilde[i, ] <- res_temp
   }
 
   return(GTilde)

--- a/R/fui.R
+++ b/R/fui.R
@@ -461,8 +461,7 @@ fui <- function(
     # Derive variance estimates of random components: H(s), R(s)
     HHat <- t(
       apply(
-        sigmausqHat,
-        1,
+        sigmausqHat, 1,
         function(b) stats::smooth.spline(x = argvals, y = b)$y
       )
     )
@@ -477,10 +476,6 @@ fui <- function(
     )
     RHat[which(RHat < 0)] <- 0
 
-    # TODO: Place this in its own function
-    # Also needs to call `select_knots` and `pspline_setting` w/in the pkg
-
-    message("Testing pspline_setting and select_knots")
     # altered fbps() function from refund to increase GCV speed (b/c lambda1=lambda2 for cov matrices b/c they're symmetric)
     fbps_cov <- function(data, subj=NULL,covariates = NULL, knots=35, knots.option="equally-spaced",
                      periodicity = c(FALSE,FALSE), p=3,m=2,lambda=NULL,
@@ -738,22 +733,19 @@ fui <- function(
     # with potential NNLS correction for diagonals (for variance terms)
     if (randint_flag) {
 
-      message("Testing integration of G_estimate_randint")
-
       GTilde <- G_estimate_randint(
         data = data,
+        L = L,
         out_index = out_index,
         designmat = designmat,
         betaHat = betaHat,
         silent = silent
       )
 
-      message("G_estimate_randint successsful.")
-
       if (silent == FALSE)
         print("Step 3.1.2: Smooth G")
 
-      diag(GTilde) <- HHat[1,] # L x L matrix
+      diag(GTilde) <- HHat[1, ] # L x L matrix
       # Fast bivariate smoother
       # nknots_min
       GHat <- fbps_cov(

--- a/man/G_estimate_randint.Rd
+++ b/man/G_estimate_randint.Rd
@@ -4,10 +4,12 @@
 \alias{G_estimate_randint}
 \title{Special case of estimating covariance of random components G(s1, s2)}
 \usage{
-G_estimate_randint(data, out_index, designmat, betaHat, silent = TRUE)
+G_estimate_randint(data, L, out_index, designmat, betaHat, silent = TRUE)
 }
 \arguments{
 \item{data}{A data frame containing all variables in formula}
+
+\item{L}{Number of columns of outcome variables}
 
 \item{out_index}{Indices that contain the outcome variables}
 


### PR DESCRIPTION
Forgot to handle both cases where out_index could be multiple columns or a Matrix column. Passing L as an argument to G_estimate_randint fixes this with better redundancy. 